### PR TITLE
Schedule remove reproduce

### DIFF
--- a/src/engine/agent.rs
+++ b/src/engine/agent.rs
@@ -1,7 +1,24 @@
+use crate::engine::priority::Priority;
+use crate::engine::schedule::ScheduleOptions;
 use crate::engine::state::State;
+use std::collections::HashMap;
 
 pub trait Agent {
     type SimState: State + Sync + Send;
 
-    fn step(&mut self,state: &Self::SimState);
+    fn step(&mut self, state: &Self::SimState);
+
+    /// Specifies whether this agent should be removed from the schedule after the current step.
+    fn should_remove(&mut self, _state: &Self::SimState) -> bool {
+        false
+    }
+
+    /// Allows the agent to schedule new agents without having direct access to the Schedule.
+    /// This should NOT return an agent that is already scheduled.
+    fn should_reproduce(
+        &mut self,
+        _state: &Self::SimState,
+    ) -> Option<HashMap<Box<Self>, ScheduleOptions>> {
+        None
+    }
 }

--- a/src/engine/field/object_grid_2d.rs
+++ b/src/engine/field/object_grid_2d.rs
@@ -52,7 +52,7 @@ impl<A: Eq + Hash + Clone + Copy> Grid2D<A> {
     /// assert_eq!(grid.get_object_location(obj), Some(&loc));
     /// ```
     pub fn set_object_location(&self, agent: A, new_pos: &Int2D) {
-        self.remove_object(agent);
+        self.remove_object(&agent);
 
         let existing_elements_vec = self.locs_inversed.get_mut(new_pos);
 
@@ -98,20 +98,20 @@ impl<A: Eq + Hash + Clone + Copy> Grid2D<A> {
     /// grid.set_object_location(obj, &loc);
     /// grid.update();
     /// assert_eq!(grid.get_object_location(obj), Some(&loc));
-    /// grid.remove_object(obj);
+    /// grid.remove_object(&obj);
     /// grid.update();
     /// assert_eq!(grid.get_object_location(obj), None);
     /// ```
-    pub fn remove_object(&self, agent: A) {
-        if let Some(old_loc) = self.locs.get(&agent) {
+    pub fn remove_object(&self, agent: &A) {
+        if let Some(old_loc) = self.locs.get(agent) {
             self.locs_inversed
                 .get_mut(old_loc)
                 .unwrap()
                 .value_mut()
-                .retain(|&x| x != agent);
+                .retain(|&x| x != *agent);
         }
 
-        self.locs.remove(&agent);
+        self.locs.remove(agent);
     }
 
     /// Fetches the copy of MyObject stored within the grid. This is necessary due to the grid being
@@ -145,10 +145,10 @@ impl<A: Eq + Hash + Clone + Copy> Grid2D<A> {
     /// grid.update();
     /// let mut obj_clone = obj.clone();
     /// // You should be able to fetch the original copy of the agent stored in the state through a local clone
-    /// assert_eq!(grid.get_object(obj_clone), Some(&obj));
+    /// assert_eq!(grid.get_object(&obj_clone), Some(&obj));
     /// ```    
-    pub fn get_object(&self, agent: A) -> Option<&A> {
-        match self.locs.get_key_value(&agent) {
+    pub fn get_object(&self, agent: &A) -> Option<&A> {
+        match self.locs.get_key_value(agent) {
             Some((updated_agent, _pos)) => Some(updated_agent),
             None => None,
         }
@@ -249,11 +249,11 @@ mod tests {
         let grid_agents = &*grid.get_object_at_location(&pos).unwrap();
         assert_eq!(agent, *grid_agents.first().unwrap());
 
-        let grid_agent = grid.get_object(agent);
+        let grid_agent = grid.get_object(&agent);
         let agent_clone = agent.clone();
         assert_eq!(grid_agent, Some(&agent_clone));
 
-        grid.remove_object(agent);
+        grid.remove_object(&agent);
         // This should still be set because we haven't updated the grid yet
         let agent_loc = *grid.get_object_location(agent).unwrap();
         assert_eq!(agent_loc, pos);
@@ -261,7 +261,7 @@ mod tests {
         grid.update();
 
         // Even though the agent has already been removed, this method shouldn't panic: nothing should be done
-        grid.remove_object(agent);
+        grid.remove_object(&agent);
 
         let agent_loc = grid.get_object_location(agent);
         assert_eq!(agent_loc, None);

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -1,3 +1,3 @@
-pub trait State{
-    fn update(&mut self){}
+pub trait State {
+    fn update(&mut self, step: usize) {}
 }

--- a/src/visualization/on_state_init.rs
+++ b/src/visualization/on_state_init.rs
@@ -23,7 +23,7 @@ pub trait OnStateInit<A: 'static + Agent + Render + Clone + Send>: Send + Sync {
     ///
     /// ```
     /// use rust_ab::visualization::on_state_init::OnStateInit;
-    /// use bevy::prelude::{Commands, ResMut};
+    /// use bevy::prelude::{Commands, ResMut, Visible};
     /// use rust_ab::visualization::sprite_render_factory::SpriteFactoryResource;
     /// use rust_ab::visualization::simulation_descriptor::SimulationDescriptor;
     /// use rust_ab::visualization::renderable::{SpriteType, Render};
@@ -55,7 +55,7 @@ pub trait OnStateInit<A: 'static + Agent + Render + Clone + Send>: Send + Sync {
     /// #   fn rotation(&self) -> f32 {
     /// #       0.
     /// #   }
-    /// #   fn update(&mut self,transform: &mut Transform,state: &Self::SimState) {
+    /// #   fn update(&mut self,transform: &mut Transform,state: &Self::SimState, visible: &mut Visible) {
     /// #       
     /// #   }
     /// # }

--- a/src/visualization/renderable.rs
+++ b/src/visualization/renderable.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Commands, Quat, SpriteBundle, Transform, Vec3};
+use bevy::prelude::{Commands, Quat, SpriteBundle, Transform, Vec3, Visible};
 
 use crate::engine::agent::Agent;
 
@@ -53,7 +53,7 @@ pub trait Render: Agent + Send + Sync + Sized + 'static {
     }
 
     /// Update the graphical variables based on the information coming from the model through the state.
-    fn update(&mut self, transform: &mut Transform, state: &Self::SimState);
+    fn update(&mut self, transform: &mut Transform, state: &Self::SimState, visible: &mut Visible);
 }
 
 pub enum SpriteType {

--- a/src/visualization/systems/renderer_system.rs
+++ b/src/visualization/systems/renderer_system.rs
@@ -1,14 +1,27 @@
-use bevy::prelude::{Query, Res, Transform};
+use bevy::prelude::{Query, Res, SpriteBundle, Transform, Visible};
 
+use crate::bevy::prelude::{Commands, ResMut};
 use crate::engine::agent::Agent;
-use crate::visualization::renderable::Render;
+use crate::engine::schedule::Schedule;
+use crate::visualization::renderable::{Render, SpriteType};
+use crate::visualization::sprite_render_factory::SpriteFactoryResource;
 
 /// The system that updates the visual representation of each agent of our simulation.
-pub fn renderer_system<A: 'static + Agent + Render + Clone + Send>(
-    mut query: Query<(&mut A, &mut Transform)>,
+pub fn renderer_system<A: Render + Clone>(
+    mut query: Query<(&mut A, &mut Transform, &mut Visible)>,
     state: Res<A::SimState>,
+    mut schedule: ResMut<Schedule<A>>,
+    mut sprite_factory: SpriteFactoryResource,
+    mut commands: Commands,
 ) {
-    for (mut render, mut transform) in query.iter_mut() {
-        render.update(&mut *transform, &state);
+    for (mut render, mut transform, mut visible) in query.iter_mut() {
+        render.update(&mut *transform, &state, &mut *visible);
+    }
+    for new_agent in &schedule.newly_scheduled {
+        let SpriteType::Emoji(emoji_code) = new_agent.sprite();
+        let sprite_render = sprite_factory.get_emoji_loader(emoji_code);
+        new_agent
+            .clone()
+            .setup_graphics(sprite_render, &mut commands, &state);
     }
 }

--- a/src/visualization/systems/simulation_system.rs
+++ b/src/visualization/systems/simulation_system.rs
@@ -1,10 +1,13 @@
 use bevy::prelude::ResMut;
 
+use crate::bevy::prelude::Commands;
 use crate::engine::agent::Agent;
 use crate::engine::schedule::Schedule;
+use crate::visualization::renderable::{Render, SpriteType};
+use crate::visualization::sprite_render_factory::{SpriteFactoryResource, SpriteRenderFactory};
 
 /// The simulation system steps the schedule once per frame, effectively synchronizing frames and schedule steps.
-pub fn simulation_system<A: 'static + Agent + Clone + Send + Sync>(
+pub fn simulation_system<A: Render + Clone>(
     mut schedule: ResMut<Schedule<A>>,
     mut state: ResMut<A::SimState>,
 ) {
@@ -19,6 +22,7 @@ mod tests {
     use bevy::prelude::{Stage, Transform};
     use bevy::prelude::{SystemStage, World};
 
+    use crate::bevy::prelude::Visible;
     use crate::engine::agent::Agent;
     use crate::engine::schedule::Schedule;
     use crate::engine::state::State;
@@ -59,7 +63,13 @@ mod tests {
             0.
         }
 
-        fn update(&mut self, _transform: &mut Transform, _state: &BasicState) {}
+        fn update(
+            &mut self,
+            _transform: &mut Transform,
+            _state: &BasicState,
+            visible: &mut Visible,
+        ) {
+        }
     }
 
     /// A simple test that sets up a basic state, agent and schedule, then schedules the single agent.

--- a/src/visualization/visualization.rs
+++ b/src/visualization/visualization.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{App, AppBuilder, ClearColor, Color, IntoSystem, WindowDescriptor};
+use bevy::prelude::*;
 use bevy::DefaultPlugins;
 
 use crate::engine::agent::Agent;
@@ -96,8 +96,8 @@ impl Visualization {
         .insert_resource(schedule)
         .add_startup_system(init_system::<A, I>.system())
         .add_plugins(DefaultPlugins)
-        .add_system(renderer_system::<A>.system())
-        .add_system(simulation_system::<A>.system());
+        .add_system(renderer_system::<A>.system().label("render"))
+        .add_system(simulation_system::<A>.system().before("render"));
         #[cfg(target_arch = "wasm32")]
         app.add_plugin(bevy_webgl2::WebGL2Plugin);
 

--- a/tests/field2d.rs
+++ b/tests/field2d.rs
@@ -1,19 +1,20 @@
-extern crate priority_queue;
-
 #[macro_use]
 extern crate lazy_static;
+extern crate priority_queue;
+
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::sync::Mutex;
 
 use rand::Rng;
+
 use rust_ab::engine::agent::Agent;
 use rust_ab::engine::field::field::Field;
 use rust_ab::engine::field::field_2d::{toroidal_distance, toroidal_transform, Field2D};
 use rust_ab::engine::location::{Location2D, Real2D};
 use rust_ab::engine::schedule::Schedule;
 use rust_ab::engine::state::State;
-use std::fmt;
-use std::hash::Hash;
-use std::hash::Hasher;
-use std::sync::Mutex;
 
 static mut _COUNT: u128 = 0;
 static _STEP: u128 = 10;
@@ -133,7 +134,7 @@ fn field_2d_test_vicinato() {
     state.field1.set_object_location(bird1, bird1.pos);
     state.field1.set_object_location(bird2, bird2.pos);
 
-    state.update();
+    state.update(0);
 
     assert_eq!(2, state.field1.num_objects());
 
@@ -151,7 +152,7 @@ fn field_2d_test_vicinato() {
         state.field1.set_object_location(bird1, bird1.pos);
         state.field1.set_object_location(bird2, bird2.pos);
 
-        state.update();
+        state.update(0);
 
         let vec = state.field1.get_neighbors_within_distance(bird1.pos, 10.0);
         assert_eq!(2, vec.len());
@@ -290,7 +291,7 @@ impl BoidsState {
 }
 
 impl State for BoidsState {
-    fn update(&mut self) {
+    fn update(&mut self, _step: usize) {
         self.field1.update();
     }
 }

--- a/tests/schedule.rs
+++ b/tests/schedule.rs
@@ -1,14 +1,15 @@
 extern crate priority_queue;
 
+use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
+
 use rust_ab::engine::agent::Agent;
 use rust_ab::engine::field::field::Field;
 use rust_ab::engine::field::field_2d::Field2D;
 use rust_ab::engine::location::{Location2D, Real2D};
-use rust_ab::engine::state::State;
-use std::fmt;
-use std::hash::Hash;
-use std::hash::Hasher;
 use rust_ab::engine::schedule::Schedule;
+use rust_ab::engine::state::State;
 
 static STEP: u128 = 10;
 // static NUM_AGENT: u128 = 2;
@@ -36,7 +37,7 @@ fn field_2d_test_1() {
     // Let's try to write only bird1 into the field
     data.field1.set_object_location(bird1, bird1.pos);
 
-    data.update();
+    data.update(schedule.step);
 
     let pos = match data.field1.get_object_location(bird1) {
         Some(i) => i,
@@ -51,7 +52,7 @@ fn field_2d_test_1() {
     data.field1
         .set_object_location(bird1, Real2D { x: 10.0, y: 10.0 });
 
-    data.update();
+    data.update(schedule.step);
 
     let pos = match data.field1.get_object_location(bird1) {
         Some(i) => i,
@@ -66,7 +67,7 @@ fn field_2d_test_1() {
     data.field1.set_object_location(bird1, real_pos);
     data.field1.set_object_location(bird2, real_pos);
 
-    data.update();
+    data.update(schedule.step);
 
     // Is the field correctly telling us there are two objects at the position used previously?
     let num = data.field1.num_objects_at_location(real_pos);
@@ -112,7 +113,7 @@ fn field_2d_test_2() {
     data.field1
         .set_object_location(bird5.clone(), bird5.pos.clone());
 
-    data.update();
+    data.update(0);
 
     let vec = data
         .field1
@@ -139,7 +140,7 @@ fn field_2d_test_2() {
     data.field1
         .set_object_location(bird6.clone(), bird6.pos.clone());
 
-    data.update();
+    data.update(0);
 
     let vec = data
         .field1
@@ -181,7 +182,7 @@ fn field_2d_test_3() {
     data.field1
         .set_object_location(bird2.clone(), bird2.pos.clone());
 
-    data.update();
+    data.update(schedule.step);
 
     let pos_b1 = match data.field1.get_object_location(bird1.clone()) {
         Some(i) => i,
@@ -193,7 +194,7 @@ fn field_2d_test_3() {
     bird1.pos = new_pos.clone();
     data.field1.set_object_location(bird1.clone(), new_pos);
 
-    data.update();
+    data.update(schedule.step);
 
     let pos_b1 = match data.field1.get_object_location(bird1.clone()) {
         Some(i) => i,
@@ -255,7 +256,7 @@ impl BoidsState {
 }
 
 impl rust_ab::engine::state::State for BoidsState {
-    fn update(&mut self) {
+    fn update(&mut self, _step: usize) {
         self.field1.update();
     }
 }

--- a/tests/schedule_helpers.rs
+++ b/tests/schedule_helpers.rs
@@ -1,0 +1,106 @@
+use rust_ab::engine::agent::Agent;
+use rust_ab::engine::priority::Priority;
+use rust_ab::engine::schedule::{Schedule, ScheduleOptions};
+use rust_ab::engine::state::State;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+#[test]
+fn schedule_helpers() {
+    let mut schedule = Schedule::new();
+    let mut state = MyState {
+        global_should_die: false,
+    };
+
+    schedule.schedule_repeating(
+        MyAgent {
+            should_die: false,
+            should_reproduce: false,
+            am_i_a_clone: false,
+        },
+        0.,
+        0,
+    );
+
+    assert_eq!(schedule.events.lock().unwrap().len(), 1);
+    // First step is taken. The first agent sets itself in reproduction mode and stands by.
+    schedule.step(&mut state);
+    println!("Step 1 finished!");
+    // The first step has been taken and the agent reproduces. There are two agents now.
+    assert_eq!(schedule.events.lock().unwrap().len(), 2);
+    // Second step is taken. The first agent schedules its own death at the end of this step.
+    // The second agent happily prints a message and stands by.
+    schedule.step(&mut state);
+    println!("Step 2 finished!");
+    // The first agent has died, the clone remains.
+    assert_eq!(schedule.events.lock().unwrap().len(), 1);
+    // Kill the remaining agent through a flag placed on the state.
+    state.global_should_die = true;
+    schedule.step(&mut state);
+    println!("Step 3 finished!");
+    // The clone was killed by the flag on the state.
+    assert_eq!(schedule.events.lock().unwrap().len(), 0);
+}
+
+pub struct MyState {
+    pub global_should_die: bool,
+}
+
+impl State for MyState {}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct MyAgent {
+    pub should_die: bool,
+    pub should_reproduce: bool,
+    pub am_i_a_clone: bool,
+}
+
+impl Agent for MyAgent {
+    type SimState = MyState;
+
+    // Clones will simply print a message. The initial agent will clone itself after the first step
+    // and die after the second.
+    fn step(&mut self, _state: &Self::SimState) {
+        if self.am_i_a_clone {
+            println!("I'm a living clone!");
+        } else {
+            // Don't reproduce if we're going to die in this step
+            if !self.should_die {
+                println!("Scheduling reproduction!");
+                self.should_reproduce = true;
+            }
+        }
+    }
+
+    fn should_remove(&mut self, state: &Self::SimState) -> bool {
+        self.should_die || state.global_should_die
+    }
+
+    fn should_reproduce(
+        &mut self,
+        _state: &Self::SimState,
+    ) -> Option<HashMap<Box<Self>, ScheduleOptions>> {
+        if self.should_reproduce {
+            self.should_reproduce = false;
+            self.should_die = true; // Die after the next step
+
+            let new_agent = MyAgent {
+                should_die: false,
+                should_reproduce: false,
+                am_i_a_clone: true,
+            };
+
+            let schedule_options = ScheduleOptions {
+                ordering: 0,
+                repeating: true,
+            };
+
+            let mut hash_map = HashMap::new();
+            hash_map.insert(Box::new(new_agent), schedule_options);
+            Some(hash_map)
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
object_grid_2d: refactors get_object to accept an immutable reference of the agent instead of taking ownership of it
schedule: passes the current step to the state update method for utility purposes, adds support for agent reproduction and death tracking via hook methods that the schedule uses to avoid a two way binding of the schedule and the state
state: added step to the update method signature
agent & schedule: Adds methods on the agent trait (with a default impl for backwards compatibility) to specify if the local agent should be removed, or if it should reproduce by scheduling new agents.

Visualization:
renderer_system: adds support to render newly scheduled agents
simulation_system: generic type trait cleanup
renderable: Added Visible to the update method signature to allow hiding the agent (for example, if it is dead)
visualization: Import cleanup, forces the execution of the simulation system before the renderer system
 schedule-remove-reproduce

Not included in this PR, but the predator prey model and visualization also works now:
![k1R0vmUPrv](https://user-images.githubusercontent.com/11891037/119047267-f8428a80-b9bd-11eb-9ef8-95d952774bd0.gif)
(the gif displays an execution with badly chosen parameters, but it's enough as proof of the simulation working)

There are some slight breaking changes, I'll update the examples accordingly.