### PR TITLE
Adds network visualization + fixes network related warnings + SpriteRenderFactory refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ahash="0.6.2"
 
 # Visualization features
 image = {version="0.23.14",optional=true}
+bevy_canvas = {version="0.1.0",optional=true}
 [dependencies.bevy]
 version= "0.5.0"
 default-features = false
@@ -61,7 +62,8 @@ visualization = [
     "bevy/bevy_gltf",
     "bevy/png",
     "bevy/bevy_wgpu",
-    "image"
+    "image",
+    "bevy_canvas"
 ]
 visualization_wasm = [
     "bevy",
@@ -69,5 +71,6 @@ visualization_wasm = [
     "bevy/render",
     "bevy/bevy_gltf",
     "bevy/png",
-    "image"
+    "image",
+    "bevy_canvas"
 ]

--- a/src/engine/agent.rs
+++ b/src/engine/agent.rs
@@ -1,7 +1,7 @@
-use crate::engine::priority::Priority;
+use std::collections::HashMap;
+
 use crate::engine::schedule::ScheduleOptions;
 use crate::engine::state::State;
-use std::collections::HashMap;
 
 pub trait Agent {
     type SimState: State + Sync + Send;

--- a/src/engine/field/object_grid_2d.rs
+++ b/src/engine/field/object_grid_2d.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use crate::engine::location::{Int2D, Location2D};
+use crate::engine::location::Int2D;
 use crate::utils::dbdashmap::DBDashMap;
 
 /// A crude implementation of a sparse double buffered grid.
@@ -213,7 +213,7 @@ impl<A: Eq + Hash + Clone + Copy> Grid2D<A> {
 #[cfg(test)]
 mod tests {
     use crate::engine::field::object_grid_2d::Grid2D;
-    use crate::engine::location::{Int2D, Location2D};
+    use crate::engine::location::Int2D;
 
     #[derive(Copy, Clone, Eq, Hash, Debug)]
     struct MyObject {

--- a/src/engine/schedule.rs
+++ b/src/engine/schedule.rs
@@ -6,7 +6,9 @@ use cfg_if::cfg_if;
 use clap::{App, Arg};
 use lazy_static::*;
 use priority_queue::PriorityQueue;
-use rayon::{ThreadPool, ThreadPoolBuilder};
+use rayon::ThreadPool;
+#[cfg(feature = "parallel")]
+use rayon::ThreadPoolBuilder;
 
 use crate::engine::agent::Agent;
 use crate::engine::agentimpl::AgentImpl;

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -1,3 +1,3 @@
 pub trait State {
-    fn update(&mut self, step: usize) {}
+    fn update(&mut self, _step: usize) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,5 @@ pub mod visualization;
 
 #[cfg(any(feature = "visualization", feature = "visualization_wasm", doc))]
 pub use bevy;
+#[cfg(any(feature = "visualization", feature = "visualization_wasm", doc))]
+pub use bevy_canvas;

--- a/src/utils/dbdashmap.rs
+++ b/src/utils/dbdashmap.rs
@@ -196,6 +196,16 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone + Default> DBDashMap<K
         ris
     }
 
+    pub fn values(&self) -> Vec<&V> {
+        let mut ris = vec![];
+        for shard in self.r_shards.iter() {
+            for value in shard.values() {
+                ris.push(value);
+            }
+        }
+        ris
+    }
+
     pub fn clear(&self) {
         for shard in self.shards.iter() {
             shard.lock().unwrap().clear();

--- a/src/visualization/field/mod.rs
+++ b/src/visualization/field/mod.rs
@@ -1,1 +1,2 @@
+pub mod network;
 pub mod number_grid_2d;

--- a/src/visualization/field/network.rs
+++ b/src/visualization/field/network.rs
@@ -1,0 +1,94 @@
+use std::fmt::Display;
+use std::hash::Hash;
+
+use bevy::prelude::Color;
+
+use crate::bevy::prelude::{Res, ResMut, Vec2};
+use crate::engine::agent::Agent;
+use crate::engine::field::network::{Edge, Network};
+use crate::engine::location::Real2D;
+use crate::visualization::renderable::Render;
+use crate::visualization::utils::arrow::Arrow;
+use bevy_canvas::{Canvas, DrawMode};
+use std::f32::consts::PI;
+
+/// Allows customization of the arrow geometry used to render edges.
+pub struct ArrowOptions {
+    pub length: f32,
+    pub angle: f32,
+}
+
+impl Default for ArrowOptions {
+    fn default() -> Self {
+        ArrowOptions {
+            length: 10.,
+            angle: PI / 12.,
+        }
+    }
+}
+
+/// Specifies the type of geometry to use to represent the edge, along with drawing directives if needed.
+pub enum LineType {
+    Line,
+    /// An arrow will be drawn with the arrow head placed on the second point. You can specify the length
+    /// of the vectors representing the arrow head segments, and the angle in radians.
+    Arrow(ArrowOptions),
+}
+
+/// All the data we need to properly visualize an edge.
+pub struct EdgeRenderInfo {
+    pub line_color: Color,
+    pub draw_mode: DrawMode,
+    pub source_loc: Real2D,
+    pub target_loc: Real2D,
+    pub line_type: LineType,
+}
+
+/// Allows rendering the edges of a graph as customizable lines through the Bevy Canvas plugin
+pub trait NetworkRender<
+    O: Hash + Eq + Clone + Display,
+    L: Clone + Hash + Display,
+    A: 'static + Agent + Render + Clone + Send,
+>
+{
+    /// Specify how to fetch a reference to the network from the state.
+    fn get_network(state: &A::SimState) -> &Network<O, L>;
+
+    /// Called for each edge to let the user specify how it should be rendered
+    fn get_edge_info(edge: &Edge<O, L>) -> EdgeRenderInfo;
+
+    fn render(state: Res<A::SimState>, mut canvas: ResMut<Canvas>) {
+        let network = Self::get_network(&*state);
+        for node_edges in network.edges.values() {
+            for edge in node_edges {
+                let EdgeRenderInfo {
+                    line_color,
+                    draw_mode,
+                    source_loc,
+                    target_loc,
+                    line_type,
+                } = Self::get_edge_info(edge);
+                // We could just use the correct geometry based on whether the network is directed or not,
+                // but that way we couldn't allow the user to configure the arrow's options.
+                match line_type {
+                    LineType::Line => {
+                        let line = bevy_canvas::common_shapes::Line(
+                            Vec2::new(source_loc.x as f32, source_loc.y as f32),
+                            Vec2::new(target_loc.x as f32, target_loc.y as f32),
+                        );
+                        canvas.draw(&line, draw_mode, line_color);
+                    }
+                    LineType::Arrow(ArrowOptions { length, angle }) => {
+                        let arrow = Arrow(
+                            Vec2::new(source_loc.x as f32, source_loc.y as f32),
+                            Vec2::new(target_loc.x as f32, target_loc.y as f32),
+                            length,
+                            angle,
+                        );
+                        canvas.draw(&arrow, draw_mode, line_color);
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/visualization/field/network.rs
+++ b/src/visualization/field/network.rs
@@ -44,7 +44,9 @@ pub struct EdgeRenderInfo {
     pub line_type: LineType,
 }
 
-/// Allows rendering the edges of a graph as customizable lines through the Bevy Canvas plugin
+/// Allows rendering the edges of a graph as customizable lines through the Bevy Canvas plugin.
+/// As for now (27/05/2021), this does NOT work in a WebGL context due to the bevy_canvas plugin not
+/// being compatible with WebGL.
 pub trait NetworkRender<
     O: Hash + Eq + Clone + Display,
     L: Clone + Hash + Display,
@@ -58,6 +60,10 @@ pub trait NetworkRender<
     fn get_edge_info(edge: &Edge<O, L>) -> EdgeRenderInfo;
 
     fn render(state: Res<A::SimState>, mut canvas: ResMut<Canvas>) {
+        if cfg!(target_arch = "wasm32") {
+            panic!("Currently network visualization does not support WebGL shaders. https://github.com/Nilirad/bevy_canvas/blob/main/src/render/mod.rs#L257");
+        }
+
         let network = Self::get_network(&*state);
         for node_edges in network.edges.values() {
             for edge in node_edges {

--- a/src/visualization/mod.rs
+++ b/src/visualization/mod.rs
@@ -4,4 +4,5 @@ pub mod renderable;
 pub mod simulation_descriptor;
 pub mod sprite_render_factory;
 mod systems;
+pub mod utils;
 pub mod visualization;

--- a/src/visualization/renderable.rs
+++ b/src/visualization/renderable.rs
@@ -56,6 +56,7 @@ pub trait Render: Agent + Send + Sync + Sized + 'static {
     fn update(&mut self, transform: &mut Transform, state: &Self::SimState, visible: &mut Visible);
 }
 
+#[derive(Clone)]
 pub enum SpriteType {
     Emoji(String),
     // File(String), TODO

--- a/src/visualization/sprite_render_factory.rs
+++ b/src/visualization/sprite_render_factory.rs
@@ -10,7 +10,7 @@ use hashbrown::HashMap;
 /// This allows loading sprites only once, storing a handle pointing to the sprite resource itself and returning clones
 /// of the handle, for optimization purposes.
 pub struct SpriteRenderFactory {
-    emoji_loaders: HashMap<String, Handle<Texture>>,
+    emoji_loaders: HashMap<String, Handle<ColorMaterial>>,
 }
 
 impl SpriteRenderFactory {
@@ -27,17 +27,8 @@ impl SpriteRenderFactory {
         materials: &mut ResMut<Assets<ColorMaterial>>,
         asset_server: &Res<AssetServer>,
     ) -> SpriteBundle {
-        let emoji_filename = format!("{}.png", emoji_code);
-        let sprite_handle = match self.emoji_loaders.get(&emoji_code) {
-            Some(handle) => handle.clone(),
-            None => {
-                let handle = self.load_emoji_sprite(asset_server, emoji_filename);
-                self.emoji_loaders.insert(emoji_code, handle.clone());
-                handle
-            }
-        };
         SpriteBundle {
-            material: materials.add(sprite_handle.into()),
+            material: self.get_material_handle(emoji_code, materials, asset_server),
             ..Default::default()
         }
     }
@@ -49,6 +40,27 @@ impl SpriteRenderFactory {
         emoji_filename: String,
     ) -> Handle<Texture> {
         asset_server.load(Path::new("emojis").join(emoji_filename))
+    }
+
+    /// The core of this factory, stores a reference of the materials handle so that it doesn't get
+    /// garbage collected and returns its clone.
+    pub fn get_material_handle(
+        &mut self,
+        emoji_code: String,
+        materials: &mut ResMut<Assets<ColorMaterial>>,
+        asset_server: &Res<AssetServer>,
+    ) -> Handle<ColorMaterial> {
+        let emoji_filename = format!("{}.png", emoji_code);
+        let material = match self.emoji_loaders.get(&emoji_code) {
+            Some(handle) => (*handle).clone(),
+            None => {
+                let handle = self.load_emoji_sprite(asset_server, emoji_filename);
+                let material = materials.add(handle.into());
+                self.emoji_loaders.insert(emoji_code, material.clone());
+                material
+            }
+        };
+        material
     }
 }
 
@@ -65,6 +77,15 @@ impl<'a> SpriteFactoryResource<'a> {
     /// A proxy method that exposes [SpriteRenderFactory get_emoji_loader](SpriteRenderFactory#get_emoji_loader)
     pub fn get_emoji_loader(&mut self, emoji_code: String) -> SpriteBundle {
         self.sprite_factory.get_emoji_loader(
+            emoji_code,
+            &mut self.materials,
+            &mut self.asset_server,
+        )
+    }
+
+    /// A proxy method that exposes [SpriteRenderFactory get_material_handle](SpriteRenderFactory#get_material_handle)
+    pub fn get_material_handle(&mut self, emoji_code: String) -> Handle<ColorMaterial> {
+        self.sprite_factory.get_material_handle(
             emoji_code,
             &mut self.materials,
             &mut self.asset_server,

--- a/src/visualization/systems/renderer_system.rs
+++ b/src/visualization/systems/renderer_system.rs
@@ -1,21 +1,30 @@
-use bevy::prelude::{Query, Res, SpriteBundle, Transform, Visible};
+use bevy::prelude::{ColorMaterial, Handle, Query, Res, Transform, Visible};
 
-use crate::bevy::prelude::{Commands, ResMut};
-use crate::engine::agent::Agent;
+use crate::bevy::prelude::Commands;
 use crate::engine::schedule::Schedule;
 use crate::visualization::renderable::{Render, SpriteType};
 use crate::visualization::sprite_render_factory::SpriteFactoryResource;
 
 /// The system that updates the visual representation of each agent of our simulation.
 pub fn renderer_system<A: Render + Clone>(
-    mut query: Query<(&mut A, &mut Transform, &mut Visible)>,
+    mut query: Query<(
+        &mut A,
+        &mut Transform,
+        &mut Visible,
+        &mut Handle<ColorMaterial>,
+    )>,
     state: Res<A::SimState>,
-    mut schedule: ResMut<Schedule<A>>,
+    schedule: Res<Schedule<A>>,
     mut sprite_factory: SpriteFactoryResource,
     mut commands: Commands,
 ) {
-    for (mut render, mut transform, mut visible) in query.iter_mut() {
+    for (mut render, mut transform, mut visible, mut material) in query.iter_mut() {
         render.update(&mut *transform, &state, &mut *visible);
+        let SpriteType::Emoji(emoji_code) = render.sprite();
+        let new_material = sprite_factory.get_material_handle(emoji_code);
+        if *material != new_material {
+            *material = new_material;
+        }
     }
     for new_agent in &schedule.newly_scheduled {
         let SpriteType::Emoji(emoji_code) = new_agent.sprite();

--- a/src/visualization/systems/simulation_system.rs
+++ b/src/visualization/systems/simulation_system.rs
@@ -1,10 +1,7 @@
 use bevy::prelude::ResMut;
 
-use crate::bevy::prelude::Commands;
-use crate::engine::agent::Agent;
 use crate::engine::schedule::Schedule;
-use crate::visualization::renderable::{Render, SpriteType};
-use crate::visualization::sprite_render_factory::{SpriteFactoryResource, SpriteRenderFactory};
+use crate::visualization::renderable::Render;
 
 /// The simulation system steps the schedule once per frame, effectively synchronizing frames and schedule steps.
 pub fn simulation_system<A: Render + Clone>(
@@ -26,7 +23,6 @@ mod tests {
     use crate::engine::agent::Agent;
     use crate::engine::schedule::Schedule;
     use crate::engine::state::State;
-    use crate::visualization::on_state_init::OnStateInit;
     use crate::visualization::renderable::{Render, SpriteType};
     use crate::visualization::systems::simulation_system::simulation_system;
 
@@ -67,7 +63,7 @@ mod tests {
             &mut self,
             _transform: &mut Transform,
             _state: &BasicState,
-            visible: &mut Visible,
+            _visible: &mut Visible,
         ) {
         }
     }

--- a/src/visualization/utils/arrow.rs
+++ b/src/visualization/utils/arrow.rs
@@ -1,0 +1,40 @@
+use crate::bevy::prelude::Vec2;
+use crate::bevy_canvas::Geometry;
+use bevy_canvas::{Path, PathBuilder};
+
+/// An arrow segment consisting of a main line, along with two small lines starting at the end point.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Arrow(pub Vec2, pub Vec2, pub f32, pub f32);
+
+impl Geometry for Arrow {
+    fn generate_path(&self) -> Path {
+        let mut b = PathBuilder::new();
+
+        let start = self.0;
+        let end = self.1;
+
+        let head_length = self.2;
+        let head_angle = self.3;
+
+        let angle = (end.y - start.y).atan2(end.x - start.x);
+        let first_head_angle = angle - head_angle;
+        let second_head_angle = angle + head_angle;
+
+        let x1 = end.x - head_length * first_head_angle.cos();
+        let x2 = end.x - head_length * second_head_angle.cos();
+
+        let y1 = end.y - head_length * first_head_angle.sin();
+        let y2 = end.y - head_length * second_head_angle.sin();
+
+        let head_point_one = Vec2::new(x1, y1);
+        let head_point_two = Vec2::new(x2, y2);
+
+        b.move_to(start);
+        b.line_to(end);
+        b.line_to(head_point_one);
+        b.move_to(end);
+        b.line_to(head_point_two);
+
+        b.build()
+    }
+}

--- a/src/visualization/utils/mod.rs
+++ b/src/visualization/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod arrow;

--- a/src/visualization/visualization.rs
+++ b/src/visualization/visualization.rs
@@ -76,6 +76,10 @@ impl Visualization {
         schedule: Schedule<A>,
     ) -> AppBuilder {
         let mut app = App::build();
+        app.add_plugins(DefaultPlugins);
+        #[cfg(target_arch = "wasm32")]
+        app.add_plugin(bevy_webgl2::WebGL2Plugin);
+
         app.insert_resource(WindowDescriptor {
             title: self.window_name.parse().unwrap(),
             width: self.width,
@@ -95,11 +99,9 @@ impl Visualization {
         .insert_resource(state)
         .insert_resource(schedule)
         .add_startup_system(init_system::<A, I>.system())
-        .add_plugins(DefaultPlugins)
+        .add_plugin(bevy_canvas::CanvasPlugin)
         .add_system(renderer_system::<A>.system().label("render"))
         .add_system(simulation_system::<A>.system().before("render"));
-        #[cfg(target_arch = "wasm32")]
-        app.add_plugin(bevy_webgl2::WebGL2Plugin);
 
         app
     }

--- a/tests/field2d.rs
+++ b/tests/field2d.rs
@@ -1,11 +1,8 @@
-#[macro_use]
-extern crate lazy_static;
 extern crate priority_queue;
 
 use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
-use std::sync::Mutex;
 
 use rand::Rng;
 

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -11,48 +11,52 @@ fn network_test_undirect() {
     let node4 = String::from("node4");
     let node5 = String::from("node5");
 
-    network.addNode(&node1);
-    network.addNode(&node2);
-    network.addNode(&node3);
-    network.addNode(&node4);
-    network.addNode(&node5);
+    network.add_node(&node1);
+    network.add_node(&node2);
+    network.add_node(&node3);
+    network.add_node(&node4);
+    network.add_node(&node5);
 
     network.lazy_update();
 
-    network.addEdge(&node1, &node2, WeightedLabeled(String::from("friend"), 2.0));
-    network.addEdge(&node1, &node3, WeightedLabeled(String::from("friend"), 2.0));
-    network.addEdge(&node3, &node4, WeightedLabeled(String::from("friend"), 2.0));
-    network.addEdge(&node4, &node1, WeightedLabeled(String::from("friend"), 2.0));
+    network.add_edge(&node1, &node2, WeightedLabeled(String::from("friend"), 2.0));
+    network.add_edge(&node1, &node3, WeightedLabeled(String::from("friend"), 2.0));
+    network.add_edge(&node3, &node4, WeightedLabeled(String::from("friend"), 2.0));
+    network.add_edge(&node4, &node1, WeightedLabeled(String::from("friend"), 2.0));
 
     network.lazy_update();
 
-    match network.getEdge(&node2, &node1) {
-        Some(edge) => assert!(true),
+    match network.get_edge(&node2, &node1) {
+        Some(_) => assert!(true),
         None => assert!(false),
     };
 
-    match network.getEdge(&node1, &node4) {
-        Some(edge) => assert!(true),
+    match network.get_edge(&node1, &node4) {
+        Some(_) => assert!(true),
         None => assert!(false),
     };
 
-    match network.getEdge(&node2, &node4) {
-        Some(edge) => assert!(false),
+    match network.get_edge(&node2, &node4) {
+        Some(_) => assert!(false),
         None => assert!(true),
     };
 
-    match network.getEdge(&node1, &node5) {
-        Some(edge) => assert!(false),
+    match network.get_edge(&node1, &node5) {
+        Some(_) => assert!(false),
         None => assert!(true),
     };
-    network.updateEdge(&node1, &node2, WeightedLabeled(String::from("friend2"), 4.0));
+    network.update_edge(
+        &node1,
+        &node2,
+        WeightedLabeled(String::from("friend2"), 4.0),
+    );
 
     network.update();
 
-    match network.getEdge(&node1, &node2) {
+    match network.get_edge(&node1, &node2) {
         Some(edge) => {
             assert_eq!(edge.label.unwrap(), "friend2");
-        },
+        }
         None => assert!(false),
     };
 }
@@ -67,38 +71,38 @@ fn network_test_direct() {
     let node4 = String::from("node4");
     let node5 = String::from("node5");
 
-    network.addNode(&node1);
-    network.addNode(&node2);
-    network.addNode(&node3);
-    network.addNode(&node4);
-    network.addNode(&node5);
+    network.add_node(&node1);
+    network.add_node(&node2);
+    network.add_node(&node3);
+    network.add_node(&node4);
+    network.add_node(&node5);
 
     network.lazy_update();
 
-    network.addEdge(&node1, &node2, WeightedLabeled(String::from("friend"), 2.0));
-    network.addEdge(&node1, &node3, WeightedLabeled(String::from("friend"), 2.0));
-    network.addEdge(&node3, &node4, WeightedLabeled(String::from("friend"), 2.0));
-    network.addEdge(&node4, &node1, WeightedLabeled(String::from("friend"), 2.0));
+    network.add_edge(&node1, &node2, WeightedLabeled(String::from("friend"), 2.0));
+    network.add_edge(&node1, &node3, WeightedLabeled(String::from("friend"), 2.0));
+    network.add_edge(&node3, &node4, WeightedLabeled(String::from("friend"), 2.0));
+    network.add_edge(&node4, &node1, WeightedLabeled(String::from("friend"), 2.0));
 
     network.lazy_update();
 
-    match network.getEdge(&node1, &node2) {
-        Some(edge) => assert!(true),
+    match network.get_edge(&node1, &node2) {
+        Some(_) => assert!(true),
         None => assert!(false),
     };
 
-    match network.getEdge(&node3, &node4) {
-        Some(edge) => assert!(true),
+    match network.get_edge(&node3, &node4) {
+        Some(_) => assert!(true),
         None => assert!(false),
     };
 
-    match network.getEdge(&node2, &node1) {
-        Some(edge) => assert!(false),
+    match network.get_edge(&node2, &node1) {
+        Some(_) => assert!(false),
         None => assert!(true),
     };
 
-    match network.getEdge(&node1, &node4) {
-        Some(edge) => assert!(false),
+    match network.get_edge(&node1, &node4) {
+        Some(_) => assert!(false),
         None => assert!(true),
     };
 }

--- a/tests/schedule.rs
+++ b/tests/schedule.rs
@@ -170,7 +170,7 @@ fn field_2d_test_3() {
     let toroidal = false;
 
     let mut data = BoidsState::new(width, heigth, discretization, toroidal);
-    let mut schedule: Schedule<Bird> = Schedule::new();
+    let schedule: Schedule<Bird> = Schedule::new();
     //assert!(schedule.events.is_empty());
     let mut bird1;
     let bird2;

--- a/tests/schedule_helpers.rs
+++ b/tests/schedule_helpers.rs
@@ -1,10 +1,8 @@
 use rust_ab::engine::agent::Agent;
-use rust_ab::engine::priority::Priority;
 use rust_ab::engine::schedule::{Schedule, ScheduleOptions};
 use rust_ab::engine::state::State;
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::hash::Hasher;
 
 #[test]
 fn schedule_helpers() {


### PR DESCRIPTION
This pull request cleans several compilation warnings due to wrong naming conventions and such, and it adds visualization for network fields. To accomplish this, bevy_canvas was added as a dependency to be able to draw geometries on a canvas object without creating entities for each geometry, which would be too costly performance-wise. As for now, support for lines and arrows has been added (the latter with a custom geometry that can be customized) and the user can choose how to render each edge of his network by changing color, line type and draw mode (which, for now, should mostly be used with the Stroke mode, but in future we might add more geometries).
The SpriteRenderFactory struct has also been refactored to support Material handles rather than textures, which allows the user to swap an agent's sprite at runtime by simply returning a different emoji in the already existing sprite method on the Render trait.

IMPORTANT: At the moment, WebGL is not supported by bevy_canvas, so network visualization won't work on wasm.